### PR TITLE
Feature: Add ability to use environment for URL

### DIFF
--- a/template/cypress.config.ts
+++ b/template/cypress.config.ts
@@ -4,7 +4,7 @@ dotenv.config();
 
 export default defineConfig({
   e2e: {
-    baseUrl: process.env.API_URL || 'https://testify.team'
+    baseUrl: process.env.URL || 'https://testify.team'
   },
   viewportWidth: 1200
 });

--- a/template/cypress.config.ts
+++ b/template/cypress.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from 'cypress';
+import dotenv from 'dotenv';
+dotenv.config();
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'https://testify.team'
+    baseUrl: process.env.API_URL || 'https://testify.team'
   },
   viewportWidth: 1200
 });

--- a/template/package.json
+++ b/template/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "cypress": "^12.5.1",
+    "dotenv": "^16.1.3",
     "cypress-ncatestify-plugin": "^2.0.16"
   }
 }


### PR DESCRIPTION
I would like to use these test with my pipelines and in a bigger scale so i would love to set the URL by environment.

* Add dotenv to package.json
* Extending the cypress.config.ts to use environment variables