### PR TITLE
Fix typo in internal-links.cy.ts

### DIFF
--- a/template/cypress/e2e/internal-links.cy.ts
+++ b/template/cypress/e2e/internal-links.cy.ts
@@ -12,7 +12,7 @@ describe('Validate links.', () => {
     cy.ttEveryInternalLinkStatusOk();  
   });
 
-  it('All interla links are loading', () => {
+  it('All internal links are loading', () => {
     cy.ttEveryInternalLinkIsLoading();  
   })  
 })


### PR DESCRIPTION
Fix typo "interla" in internal-links.cy.ts